### PR TITLE
MOC crun.py Class

### DIFF
--- a/crun.py
+++ b/crun.py
@@ -1286,13 +1286,13 @@ class crun_hpc_moc(crun_hpc):
 
         self._b_emailWhenDone           = False
 
-        self._str_emailUser             = "rudolph"
+        self._str_emailUser             = ''
         if len(self._str_remoteUser):
             self._str_jobInfoDir    = "/pbs/%s" % self._str_remoteUser
         else:
             self._str_jobInfoDir    = "/pbs/%s" % self._str_emailUser
         self._b_singleQuoteCmd          = True
-        self._str_queue                 = "max200"
+        self._str_queue                 = ''
 
         self._priority                  = 50
         self._str_scheduler             = '/home/chris/src/rabbitmq/chris_scheduler.py'


### PR DESCRIPTION
This addition is part of BU EC 500 course project with mentoring from Dr. Pienaar to include an option in chrisreloaded for computing using a cluster on the Massachusetts Open Cloud (MOC). We have added the class 'crun_hpc_moc' and have modeled it after other 'crun_hpc' classes in crun.py. The scheduler being called is '/home/chris/src/rabbitmq/chris_scheduler.py', which uses [RabbitMQ](https://www.rabbitmq.com) to monitor and schedule tasks on worker nodes. This MOC scheduler will be included separately. We will discuss with Dr. Pienaar how best to make it available to BCH. 

We tried to keep 'crun_hpc_moc' simple. It's main function is to apply the scheduler prefix to the command from ChRIS. In the current implementation the 'killJob' and 'queueInfo' functions do not work due to our scheduling method. 

If there anything you would like us to change or add please let us know. We are happy to help and want to make this as easy to use as possible.  

-Travis Miller, Kristi Nikolla, Roberto Reyes, and Xingyu Wu
